### PR TITLE
Fix Prettier regex pattern 

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "jest --watch --config --coverage jest.config.json",
-    "format": "prettier --write 'src/**/*.ts'"
+    "format": "prettier --write \"src/**/*.ts\""
   },
   "devDependencies": {
     "@types/jest": "^25.2.3",


### PR DESCRIPTION
Your `npm format` command not working due to single quote arround the regex pattern. 
Prefer and use escaped double quotes instead.
[Prettier install](https://prettier.io/docs/en/install.html)